### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,5 +9,7 @@
       "default"
     ],
     "sharedGlobals": []
-  }
+  },
+  "nxCloudAccessToken": "OGFmNGMxZWMtODRiNC00ZDE0LThhN2UtYzU2ZTE2ZDlkYzEzfHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "http://localhost:4202"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
http://localhost:4202/orgs/6650df549638fa404bfb399f/workspaces/667ab169cc06965774350661

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.